### PR TITLE
Fix missing Trainer export

### DIFF
--- a/src/tritter/training/__init__.py
+++ b/src/tritter/training/__init__.py
@@ -120,4 +120,9 @@ class Trainer:
         )
 
 
-__all__ = ["Trainer", "EmbeddingPredictionLoss", "CurriculumScheduler"]
+# TODO: Phase 6 - Export Trainer, EmbeddingPredictionLoss, and CurriculumScheduler
+# These classes are stub implementations that raise NotImplementedError.
+# Once they are fully implemented with working functionality, add them to __all__.
+# Implementation requires: (1) stable model architecture, (2) validated quantization,
+# (3) chosen training framework (Nanotron per project-plan.md)
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- Remove Trainer, EmbeddingPredictionLoss, and CurriculumScheduler from __all__ since they are stub implementations that raise NotImplementedError
- Add TODO comment noting these will be implemented in Phase 6 once model architecture stabilizes
- Ensures __all__ only exports what is actually importable, per DEVELOPMENT_STANDARDS.md

## Test plan
- [x] Python syntax check passes
- [x] File compiles without errors  
- [x] git diff shows only the __all__ change with TODO comment
- [x] Commit message includes 'Closes #18'

Generated with Claude Code

## Summary by Sourcery

Restrict training module exports to only fully implemented components and document future export plans for unimplemented training stubs.

Enhancements:
- Remove stub training classes from the package export list so only usable symbols are publicly exposed.
- Add documentation comments outlining the future implementation and export of training-related classes once the architecture and tooling are finalized.