### PR TITLE
Fix missing tokenization exports

### DIFF
--- a/src/tritter/tokenization/__init__.py
+++ b/src/tritter/tokenization/__init__.py
@@ -1,5 +1,5 @@
 """Multimodal tokenization for text, code, image, and audio."""
 
-from tritter.tokenization.multimodal import ModalityType, MultiModalTokenizer
+from .multimodal import ModalityType, MultiModalTokenizer
 
 __all__ = ["MultiModalTokenizer", "ModalityType"]


### PR DESCRIPTION
## Summary
- Fixed tokenization module exports by changing absolute import to relative import
- Changed `from tritter.tokenization.multimodal import ...` to `from .multimodal import ...`
- Ensures static analysis tools properly recognize ModalityType and MultiModalTokenizer as defined

## Details
The symbols were already functional at runtime, but some static analyzers (like Copilot PR reviewer) prefer relative imports in `__init__.py` files to clearly indicate that symbols are defined within the package scope.

## Testing
- ✅ All existing tokenization tests pass (11/11)
- ✅ Ruff linting passes
- ✅ Ruff formatting passes
- ✅ Imports verified to work correctly

## Closes
- Closes #15 (ModalityType export)
- Closes #16 (MultiModalTokenizer export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct tokenization package imports to ensure ModalityType and MultiModalTokenizer are reliably exported for static analysis and consumers.