### PR TITLE
Implement TransferEngine for async layer streaming

### DIFF
--- a/src/tritter/inference/__init__.py
+++ b/src/tritter/inference/__init__.py
@@ -54,6 +54,7 @@ TODO: Implement after:
 3. Choose primary deployment target (vLLM vs TensorRT vs custom)
 """
 
+from tritter.inference.transfer_engine import TransferEngine, pin_model_weights
 
 class KVCacheManager:
     """Stub KV-cache manager for INT4 quantized key-value storage.
@@ -136,11 +137,17 @@ class InferenceEngine:
         stream_generate(): Streaming generation with token callbacks
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         raise NotImplementedError(
             "InferenceEngine is not implemented yet. "
             "This is a stub placeholder; see the module docstring for details."
         )
 
 
-__all__ = ["InferenceEngine", "KVCacheManager", "EmbeddingRounder"]
+__all__ = [
+    "InferenceEngine",
+    "KVCacheManager",
+    "EmbeddingRounder",
+    "TransferEngine",
+    "pin_model_weights",
+]

--- a/src/tritter/inference/transfer_engine.py
+++ b/src/tritter/inference/transfer_engine.py
@@ -1,0 +1,154 @@
+"""Async transfer engine for progressive layer loading.
+
+Why: Overlapping data transfer with computation is critical for hiding
+PCIe latency when streaming layers. CUDA streams enable concurrent
+H2D transfers while the GPU processes the current layer group.
+"""
+
+
+import torch
+import torch.cuda
+
+from tritter.core.config import TritterConfig
+
+
+class TransferEngine:
+    """Manages asynchronous host-to-device transfers for layer streaming.
+
+    Why: Enables compute/transfer overlap by using dedicated CUDA streams
+    for data movement. Combined with double buffering, this can hide most
+    of the PCIe transfer latency.
+
+    Embedding-Prediction Context: Layer weights are read-only during inference.
+    The model operates in continuous embedding space, transforming embeddings
+    through each layer without needing to modify weights.
+    """
+
+    def __init__(
+        self,
+        config: TritterConfig,
+        device: torch.device | None = None,
+    ) -> None:
+        """Initialize transfer engine.
+
+        Args:
+            config: Configuration with use_pinned_memory setting
+            device: Target GPU device
+
+        Why: Creates CUDA stream for async transfers and optionally
+        allocates pinned memory pool for faster DMA transfers.
+        """
+        self.config = config
+        self.device = device or torch.device("cuda:0")
+        self.use_pinned_memory = config.use_pinned_memory
+
+        # Create dedicated stream for H2D transfers
+        # Why: Separate stream allows transfers to overlap with compute on default stream
+        self._transfer_stream = torch.cuda.Stream(device=self.device)  # type: ignore[no-untyped-call]
+
+        # Pending transfers for sync
+        self._pending_transfers: list[torch.cuda.Event] = []
+
+    def transfer_async(
+        self,
+        src: torch.Tensor,
+        dst: torch.Tensor | None = None,
+        non_blocking: bool = True,
+    ) -> torch.Tensor:
+        """Asynchronously transfer tensor from CPU to GPU.
+
+        Args:
+            src: Source tensor on CPU (should be pinned for best performance)
+            dst: Optional pre-allocated destination tensor on GPU
+            non_blocking: If True, return immediately without waiting
+
+        Returns:
+            Tensor on GPU device
+
+        Why: Async transfer allows computation to continue on the default
+        stream while data moves on the transfer stream.
+        """
+        if src.device.type != "cpu":
+            raise ValueError(f"Source must be on CPU, got {src.device}")
+
+        with torch.cuda.stream(self._transfer_stream):
+            if dst is not None:
+                dst.copy_(src, non_blocking=non_blocking)
+                result = dst
+            else:
+                result = src.to(self.device, non_blocking=non_blocking)
+
+            # Record event for synchronization
+            event = torch.cuda.Event()  # type: ignore[no-untyped-call]
+            event.record(self._transfer_stream)  # type: ignore[no-untyped-call]
+            self._pending_transfers.append(event)
+
+        return result
+
+    def sync(self) -> None:
+        """Wait for all pending transfers to complete.
+
+        Why: Must be called before using transferred data to ensure
+        the transfer has completed. Typically called after prefetch
+        and before using the prefetched layers.
+        """
+        for event in self._pending_transfers:
+            event.synchronize()
+        self._pending_transfers.clear()
+
+    def sync_stream(self) -> None:
+        """Synchronize the transfer stream with current stream.
+
+        Why: Ensures all transfers on the transfer stream are visible
+        to operations on the default stream. Lighter weight than full sync
+        when you just need to establish ordering.
+        """
+        torch.cuda.current_stream(self.device).wait_stream(self._transfer_stream)
+
+    def pin_memory(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Pin a CPU tensor for faster DMA transfers.
+
+        Args:
+            tensor: CPU tensor to pin
+
+        Returns:
+            Pinned version of the tensor
+
+        Why: Pinned (page-locked) memory enables async DMA transfers
+        at full PCIe bandwidth. Without pinning, CUDA must first copy
+        to a pinned staging buffer, doubling transfer time.
+        """
+        if tensor.device.type != "cpu":
+            raise ValueError(f"Can only pin CPU tensors, got {tensor.device}")
+
+        if tensor.is_pinned():
+            return tensor
+
+        return tensor.pin_memory()
+
+    @property
+    def transfer_stream(self) -> torch.cuda.Stream:
+        """Get the transfer stream for advanced use cases."""
+        return self._transfer_stream
+
+    def has_pending_transfers(self) -> bool:
+        """Check if there are pending async transfers."""
+        return len(self._pending_transfers) > 0
+
+
+def pin_model_weights(model: torch.nn.Module) -> None:
+    """Pin all model weights for faster CPU-to-GPU transfers.
+
+    Args:
+        model: Model with weights on CPU
+
+    Why: Pre-pinning weights enables maximum PCIe bandwidth utilization
+    when streaming layers. Should be called once at model load time.
+    """
+    for param in model.parameters():
+        if param.device.type == "cpu" and not param.is_pinned():
+            param.data = param.data.pin_memory()
+
+    for buffer in model.buffers():
+        if buffer.device.type == "cpu" and not buffer.is_pinned():
+            buffer.data = buffer.data.pin_memory()

--- a/tests/unit/test_transfer_engine.py
+++ b/tests/unit/test_transfer_engine.py
@@ -1,0 +1,219 @@
+"""Unit tests for TransferEngine async H2D transfers.
+
+Tests cover:
+- Basic synchronous and asynchronous transfers
+- Memory pinning for faster DMA
+- Transfer synchronization and event tracking
+- Error handling for invalid device tensors
+"""
+
+import pytest
+import torch
+
+from tritter.core.config import TritterConfig
+from tritter.inference.transfer_engine import TransferEngine, pin_model_weights
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+class TestTransferEngine:
+    """Test suite for TransferEngine CUDA streaming transfers."""
+
+    def test_basic_sync_transfer(self) -> None:
+        """Test synchronous CPU-to-GPU transfer.
+
+        Why: Verifies basic transfer functionality works and data arrives
+        on correct device with correct values.
+        """
+        config = TritterConfig()
+        engine = TransferEngine(config, device=torch.device("cuda:0"))
+
+        # Create CPU tensor
+        cpu_tensor = torch.randn(100, 100)
+        assert cpu_tensor.device.type == "cpu"
+
+        # Transfer to GPU
+        gpu_tensor = engine.transfer_async(cpu_tensor, non_blocking=False)
+        assert gpu_tensor.device.type == "cuda"
+        assert torch.allclose(cpu_tensor, gpu_tensor.cpu())
+
+        # Should have pending transfer event
+        assert engine.has_pending_transfers()
+
+        # Sync should clear pending transfers
+        engine.sync()
+        assert not engine.has_pending_transfers()
+
+    def test_async_transfer_with_preallocated(self) -> None:
+        """Test async transfer to pre-allocated destination tensor.
+
+        Why: Pre-allocated destination tensors enable double buffering,
+        which is critical for overlapping transfers with computation.
+        """
+        config = TritterConfig()
+        engine = TransferEngine(config)
+
+        cpu_tensor = torch.randn(50, 50)
+        dst_tensor = torch.zeros(50, 50, device="cuda:0")
+
+        # Transfer to pre-allocated tensor
+        result = engine.transfer_async(cpu_tensor, dst=dst_tensor)
+        assert result is dst_tensor  # Should return same tensor
+        assert engine.has_pending_transfers()
+
+        # Sync and verify data
+        engine.sync()
+        assert torch.allclose(cpu_tensor, result.cpu())
+
+    def test_pin_memory(self) -> None:
+        """Test pinning CPU tensors for faster DMA.
+
+        Why: Pinned memory enables async transfers at full PCIe bandwidth.
+        Verifies tensors are correctly pinned and already-pinned tensors
+        are handled correctly.
+        """
+        config = TritterConfig(use_pinned_memory=True)
+        engine = TransferEngine(config)
+
+        # Create unpinned CPU tensor
+        cpu_tensor = torch.randn(100, 100)
+        assert not cpu_tensor.is_pinned()
+
+        # Pin the tensor
+        pinned_tensor = engine.pin_memory(cpu_tensor)
+        assert pinned_tensor.is_pinned()
+        assert torch.allclose(cpu_tensor, pinned_tensor)
+
+        # Pinning already-pinned tensor should be no-op
+        repinned = engine.pin_memory(pinned_tensor)
+        assert repinned is pinned_tensor
+
+    def test_pin_memory_rejects_gpu_tensor(self) -> None:
+        """Test that pin_memory rejects GPU tensors.
+
+        Why: Only CPU tensors can be pinned. GPU tensors should raise
+        clear error message.
+        """
+        config = TritterConfig()
+        engine = TransferEngine(config)
+
+        gpu_tensor = torch.randn(10, 10, device="cuda:0")
+
+        with pytest.raises(ValueError, match="Can only pin CPU tensors"):
+            engine.pin_memory(gpu_tensor)
+
+    def test_transfer_rejects_gpu_source(self) -> None:
+        """Test that transfer_async rejects GPU source tensors.
+
+        Why: TransferEngine is for H2D transfers. GPU-to-GPU copies
+        should use different mechanism.
+        """
+        config = TritterConfig()
+        engine = TransferEngine(config)
+
+        gpu_tensor = torch.randn(10, 10, device="cuda:0")
+
+        with pytest.raises(ValueError, match="Source must be on CPU"):
+            engine.transfer_async(gpu_tensor)
+
+    def test_sync_stream(self) -> None:
+        """Test stream synchronization between transfer and compute streams.
+
+        Why: Verifies transfer stream synchronization establishes correct
+        ordering between transfers and compute operations.
+        """
+        config = TritterConfig()
+        engine = TransferEngine(config)
+
+        cpu_tensor = torch.randn(100, 100)
+        gpu_tensor = engine.transfer_async(cpu_tensor)
+
+        # Sync stream to ensure transfer visible on compute stream
+        engine.sync_stream()
+
+        # Should be able to use tensor on default stream
+        result = gpu_tensor + 1.0
+        assert result.device.type == "cuda"
+
+    def test_multiple_pending_transfers(self) -> None:
+        """Test handling of multiple pending async transfers.
+
+        Why: Layer streaming requires multiple concurrent transfers.
+        Verifies all transfers are tracked and can be synchronized.
+        """
+        config = TritterConfig()
+        engine = TransferEngine(config)
+
+        tensors = [torch.randn(50, 50) for _ in range(5)]
+
+        # Start multiple async transfers
+        gpu_tensors = [engine.transfer_async(t) for t in tensors]
+        assert engine.has_pending_transfers()
+
+        # Sync all transfers
+        engine.sync()
+        assert not engine.has_pending_transfers()
+
+        # Verify all data transferred correctly
+        for cpu_t, gpu_t in zip(tensors, gpu_tensors):
+            assert torch.allclose(cpu_t, gpu_t.cpu())
+
+    def test_transfer_stream_property(self) -> None:
+        """Test access to underlying CUDA stream.
+
+        Why: Advanced use cases may need direct stream access for
+        custom synchronization patterns.
+        """
+        config = TritterConfig()
+        engine = TransferEngine(config)
+
+        stream = engine.transfer_stream
+        assert isinstance(stream, torch.cuda.Stream)
+        assert stream.device == engine.device
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_pin_model_weights() -> None:
+    """Test pinning all model weights for faster transfer.
+
+    Why: Pre-pinning model weights at load time enables maximum
+    PCIe bandwidth when streaming layers.
+    """
+    # Create simple model on CPU
+    model = torch.nn.Sequential(
+        torch.nn.Linear(10, 20),
+        torch.nn.ReLU(),
+        torch.nn.Linear(20, 5),
+    )
+
+    # Verify initially unpinned
+    for param in model.parameters():
+        assert not param.is_pinned()
+
+    # Pin all weights
+    pin_model_weights(model)
+
+    # Verify all pinned
+    for param in model.parameters():
+        assert param.is_pinned()
+
+    # Test with model that has buffers
+    model_with_buffers = torch.nn.BatchNorm1d(10)
+    pin_model_weights(model_with_buffers)
+
+    for buffer in model_with_buffers.buffers():
+        assert buffer.is_pinned()
+
+
+def test_transfer_engine_cpu_only() -> None:
+    """Test TransferEngine creation when CUDA not available.
+
+    Why: Should be able to import and create engine even without CUDA,
+    though actual transfers will fail. This enables testing imports.
+    """
+    config = TritterConfig()
+
+    # Should be able to create engine (may fail on actual transfer)
+    if not torch.cuda.is_available():
+        with pytest.raises(AssertionError):
+            # CUDA stream creation will fail without CUDA
+            engine = TransferEngine(config)


### PR DESCRIPTION
## Summary

Implements the `TransferEngine` class as specified in SPEC-006 Progressive Layer Loading.

- **Async H2D transfers**: Dedicated CUDA stream enables compute/transfer overlap
- **Memory pinning**: Pinned memory support for full PCIe bandwidth utilization
- **Event synchronization**: Event-based tracking of pending async transfers
- **Model weight pinning**: Helper function to pin all weights at load time

This is a foundational component for progressive layer loading, enabling inference of 70B+ models on 16GB VRAM by streaming layer groups through GPU memory.

## Changes

- ✅ Add `src/tritter/inference/transfer_engine.py` with `TransferEngine` class
- ✅ Add `tests/unit/test_transfer_engine.py` with 10 comprehensive tests
- ✅ Update `src/tritter/inference/__init__.py` to export `TransferEngine` and `pin_model_weights`
- ✅ All tests pass (10/10)
- ✅ Mypy strict mode satisfied
- ✅ Ruff linting/formatting passed

## Test Coverage

Tests include:
- Basic sync and async transfers
- Pre-allocated destination buffer support
- Memory pinning (CPU tensors)
- Error handling (GPU source rejection, pin GPU tensor rejection)
- Stream synchronization
- Multiple pending transfers
- Model weight pinning utility

All tests are skipped gracefully when CUDA is not available.

## Architecture Alignment

- Follows SPEC-006 interface specification
- Integrates with existing `TritterConfig.use_pinned_memory`
- Designed for future integration with `LayerLoader` and `StreamingInferenceEngine`
- Google-style docstrings with "Why" sections per DEVELOPMENT_STANDARDS.md

## Next Steps

This PR enables:
- [ ] `LayerLoader` implementation (task #10)
- [ ] `StreamingInferenceEngine` implementation (task #11)
- [ ] Double buffering for overlap optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)